### PR TITLE
Signal on model save to update cache.

### DIFF
--- a/banish/middleware.py
+++ b/banish/middleware.py
@@ -92,7 +92,8 @@ class BanishMiddleware(object):
         """
         cache_key = self.ABUSE_PREFIX + ip
         abuse_count = cache.get(cache_key)
-        print >> sys.stderr, "ABUSE COUNT: ", abuse_count
+        if self.DEBUG:
+            print >> sys.stderr, "ABUSE COUNT: ", abuse_count
 
         over_abuse_limit = False
 

--- a/banish/models.py
+++ b/banish/models.py
@@ -16,6 +16,10 @@
 import datetime
 
 from django.db import models
+from django.db.models.signals import post_save
+from django.core.cache import cache
+
+BANISH_PREFIX = 'DJANGO_BANISH:'
 
 
 class Banishment(models.Model):
@@ -65,3 +69,11 @@ class Banishment(models.Model):
         verbose_name = "Banishments"
         verbose_name_plural = "Banishments"
         db_table = 'banishments'
+
+
+def _update_cache(sender, instance, **kwargs):
+     if instance.type == 'ip-address':
+        cache_key = BANISH_PREFIX + instance.condition
+        cache.set(cache_key, "1")  
+
+post_save.connect(_update_cache, sender=Banishment)


### PR DESCRIPTION
This way, admins can manually add bans via the admin interface.
