### PR TITLE
add settings config to specify cache django-banish uses

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ In your django project settings.py you must set the following options:
     5) Optionally set BANISH_ABUSE_THRESHOLD (default is 75) to the threshold of requests per minute
 
     6) Optionally set BANISH_MESSAGE (default is "You are banned.") to change default message for banned user.
+    
+    7) Optionally set DJANGO_BANISH_CACHE to the name of the cache from settings.CACHES you want to use. Will you 'default' cache by default. If your cache is in-memory/per process you'll want to add a cache shared application wide to settings.CACHES and specify it here.
 
 Issues
 ------

--- a/banish/middleware.py
+++ b/banish/middleware.py
@@ -19,9 +19,11 @@ import django
 from django.conf import settings
 from django.http import HttpResponseForbidden
 from django.core.exceptions import MiddlewareNotUsed
-from django.core.cache import cache
+from django.core.cache import caches
 
 from models import Banishment, Whitelist
+
+cache = caches[getattr(settings, 'DJANGO_BANISH_CACHE', 'default')]
 
 
 class BanishMiddleware(object):

--- a/banish/models.py
+++ b/banish/models.py
@@ -17,7 +17,10 @@ import datetime
 
 from django.db import models
 from django.db.models.signals import post_save, post_delete
-from django.core.cache import cache
+from django.core.cache import caches
+from django.conf import settings
+
+cache = caches[getattr(settings, 'DJANGO_BANISH_CACHE', 'default')]
 
 ABUSE_PREFIX = 'DJANGO_BANISH_ABUSE:'
 BANISH_PREFIX = 'DJANGO_BANISH:'


### PR DESCRIPTION
simple enough change that i find is pretty useful. if your default cache is a memory based one monitor abuse will only work per-process instead of across all instances of the application